### PR TITLE
rutorrent: fixed package dependencies and enforcement of basic acl rights when web directory is in Linux mode

### DIFF
--- a/spk/rutorrent/Makefile
+++ b/spk/rutorrent/Makefile
@@ -1,6 +1,6 @@
 SPK_NAME = rutorrent
 SPK_VERS = 3.10
-SPK_REV = 10
+SPK_REV = 11
 SPK_ICON = src/rutorrent.png
 DSM_UI_DIR = app
 
@@ -18,7 +18,7 @@ ADMIN_URL = /rutorrent/
 RELOAD_UI = yes
 STARTABLE = yes
 DISPLAY_NAME = ruTorrent
-CHANGELOG = "1. Update rutorrent to 3.10<br/>2. Update rtorrent to 0.9.8<br/>3. Update openssl to 1.1<br/>4. Fix bug issue no. 4295<br/>5. Move rtorrent configuration file to web volume for direct user access"
+CHANGELOG = "Fixed dependencies and access rights enforcement"
 
 HOMEPAGE   = https://github.com/Novik/ruTorrent
 LICENSE    = GPLv3
@@ -42,9 +42,9 @@ POST_STRIP_TARGET = rutorrent_extra_install
 BUSYBOX_CONFIG = usrmng nice procutils
 ENV += BUSYBOX_CONFIG="$(BUSYBOX_CONFIG)"
 
-include ../../mk/spksrc.spk.mk
+SPK_DEPENDS = "python3>=3.7.7:WebStation"
 
-SPK_DEPENDS = "python3>=3.7.7:php5.6"
+include ../../mk/spksrc.spk.mk
 
 .PHONY: rutorrent_extra_install
 rutorrent_extra_install:


### PR DESCRIPTION

_Motivation:_  Initial setup of acl rights could fail in some context
_Linked issues:_  https://github.com/SynoCommunity/spksrc/issues/4411

### Checklist
- [x] Build rule `all-supported` completed successfully
- [ ] Package upgrade completed successfully
- [ ] New installation of package completed successfully
